### PR TITLE
Updates for Accumulo 2.1.0 SLF4J2 and new MIME type

### DIFF
--- a/modules/vfs-class-loader/pom.xml
+++ b/modules/vfs-class-loader/pom.xml
@@ -98,6 +98,18 @@
       <artifactId>hadoop-client-minicluster</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.19.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/modules/vfs-class-loader/src/main/java/org/apache/accumulo/classloader/vfs/VFSManager.java
+++ b/modules/vfs-class-loader/src/main/java/org/apache/accumulo/classloader/vfs/VFSManager.java
@@ -179,6 +179,7 @@ public class VFSManager {
       VFS.addMimeTypeMap("application/x-tar", "tar");
       VFS.addMimeTypeMap("application/x-gzip", "gz");
       VFS.addMimeTypeMap("application/zip", "zip");
+      VFS.addMimeTypeMap("application/java-archive", "jar");
       VFS.setFileContentInfoFactory(new FileContentInfoFilenameFactory());
       VFS.setFilesCache(new SoftRefFilesCache());
       File cacheDir = computeTopCacheDir();

--- a/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/AccumuloDFSBase.java
+++ b/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/AccumuloDFSBase.java
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.vfs2.CacheStrategy;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.cache.DefaultFilesCache;
 import org.apache.commons.vfs2.cache.SoftRefFilesCache;
 import org.apache.commons.vfs2.impl.DefaultFileReplicator;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
@@ -108,7 +107,6 @@ public class AccumuloDFSBase {
     // Set up the VFS
     vfs = new DefaultFileSystemManager();
     try {
-      vfs.setFilesCache(new DefaultFilesCache());
       vfs.addProvider("res", new org.apache.commons.vfs2.provider.res.ResourceFileProvider());
       vfs.addProvider("zip", new org.apache.commons.vfs2.provider.zip.ZipFileProvider());
       vfs.addProvider("gz", new org.apache.commons.vfs2.provider.gzip.GzipFileProvider());
@@ -141,6 +139,7 @@ public class AccumuloDFSBase {
       vfs.addMimeTypeMap("application/x-tar", "tar");
       vfs.addMimeTypeMap("application/x-gzip", "gz");
       vfs.addMimeTypeMap("application/zip", "zip");
+      vfs.addMimeTypeMap("application/java-archive", "jar");
       vfs.setFileContentInfoFactory(new FileContentInfoFilenameFactory());
       vfs.setFilesCache(new SoftRefFilesCache());
       vfs.setReplicator(new DefaultFileReplicator(new File(System.getProperty("java.io.tmpdir"),
@@ -153,15 +152,15 @@ public class AccumuloDFSBase {
 
   }
 
-  public Configuration getConfiguration() {
+  public static Configuration getConfiguration() {
     return conf;
   }
 
-  public MiniDFSCluster getCluster() {
+  public static MiniDFSCluster getCluster() {
     return cluster;
   }
 
-  public DefaultFileSystemManager getDefaultFileSystemManager() {
+  public static DefaultFileSystemManager getDefaultFileSystemManager() {
     return vfs;
   }
 

--- a/modules/vfs-class-loader/src/test/resources/log4j2-test.properties
+++ b/modules/vfs-class-loader/src/test/resources/log4j2-test.properties
@@ -27,6 +27,9 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
 
-rootLogger.level = info
+logger.01.name = org.apache.hadoop
+logger.01.level = warn
+
+rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-08-27T15:56:15Z</project.build.outputTimestamp>
-    <slf4j.version>1.7.35</slf4j.version>
+    <slf4j.version>2.0.3</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
   </properties>
   <dependencyManagement>
@@ -208,8 +208,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.17.2</version>
+        <artifactId>log4j-slf4j2-impl</artifactId>
+        <version>2.19.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Accumulo 2.1.0 recently upgraded slf4j to slf4j2. I updated the poms to account for the new version and additional dependency. Two of the tests were also failing, which turned out to be caused by the backport of JDK-8273655. Adding a mime type mapping for application/java-archive resolved the issue. While debugging I restructured the VFSClassLoaderTest.