### PR TITLE
Make test scripts clean up duplicate classes

### DIFF
--- a/modules/vfs-class-loader/src/test/shell/makeHelloWorldJars.sh
+++ b/modules/vfs-class-loader/src/test/shell/makeHelloWorldJars.sh
@@ -26,8 +26,10 @@ mkdir -p target/generated-sources/HelloWorld/test
 sed "s/%%/Hello World\!/" < src/test/java/test/HelloWorldTemplate > target/generated-sources/HelloWorld/test/HelloWorld.java
 $JAVA_HOME/bin/javac target/generated-sources/HelloWorld/test/HelloWorld.java -d target/generated-sources/HelloWorld
 $JAVA_HOME/bin/jar -cf target/test-classes/HelloWorld.jar -C target/generated-sources/HelloWorld test/HelloWorld.class
+rm -r target/generated-sources/HelloWorld/test
 
 mkdir -p target/generated-sources/HalloWelt/test
 sed "s/%%/Hallo Welt/" < src/test/java/test/HelloWorldTemplate > target/generated-sources/HalloWelt/test/HelloWorld.java
 $JAVA_HOME/bin/javac target/generated-sources/HalloWelt/test/HelloWorld.java -d target/generated-sources/HalloWelt
 $JAVA_HOME/bin/jar -cf target/test-classes/HelloWorld2.jar -C target/generated-sources/HalloWelt test/HelloWorld.class
+rm -r target/generated-sources/HalloWelt/test

--- a/modules/vfs-class-loader/src/test/shell/makeTestJars.sh
+++ b/modules/vfs-class-loader/src/test/shell/makeTestJars.sh
@@ -29,4 +29,5 @@ do
     sed "s/testX/test$x/" < src/test/java/test/TestTemplate > target/generated-sources/$x/test/TestObject.java
     $JAVA_HOME/bin/javac -cp target/test-classes target/generated-sources/$x/test/TestObject.java -d target/generated-sources/$x
     $JAVA_HOME/bin/jar -cf target/test-classes/ClassLoaderTest$x/Test.jar -C target/generated-sources/$x test/TestObject.class
+    rm -r target/generated-sources/$x
 done


### PR DESCRIPTION
The test scripts in start create multiple classes with the same name that can cause problems for IDEs. The classes are only used to create jars for the VFS tests so just drop the intermediate class files when done creating the jars.

Note: This is the same fix used in Accumulo:
https://github.com/apache/accumulo/commit/f5121ec