### PR TITLE
Remove usage of deprecated AccessController

### DIFF
--- a/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/VfsClassLoaderTest.java
+++ b/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/VfsClassLoaderTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 
 import org.apache.commons.vfs2.FileChangeEvent;
@@ -82,17 +80,14 @@ public class VfsClassLoaderTest extends AccumuloDFSBase {
     FileObject[] dirContents = testDir.getChildren();
     LOG.info("Test directory contents according to VFS: {}", Arrays.toString(dirContents));
 
-    VFSClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<VFSClassLoader>() {
-      @Override
-      public VFSClassLoader run() {
-        // Point the VFSClassLoader to all of the objects in TEST_DIR
-        try {
-          return new VFSClassLoader(dirContents, vfs);
-        } catch (FileSystemException e) {
-          throw new RuntimeException("Error creating VFSClassLoader", e);
-        }
-      }
-    });
+    final VFSClassLoader cl;
+
+    // Point the VFSClassLoader to all of the objects in TEST_DIR
+    try {
+      cl = new VFSClassLoader(dirContents, vfs);
+    } catch (FileSystemException e) {
+      throw new RuntimeException("Error creating VFSClassLoader", e);
+    }
 
     LOG.info("VFSClassLoader has the following files: {}", Arrays.toString(cl.getFileObjects()));
     LOG.info("Looking for HelloWorld.class");

--- a/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/context/ReloadingVFSContextClassLoaderFactoryTest.java
+++ b/modules/vfs-class-loader/src/test/java/org/apache/accumulo/classloader/vfs/context/ReloadingVFSContextClassLoaderFactoryTest.java
@@ -28,8 +28,6 @@ import static org.junit.Assert.fail;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.nio.file.Files;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,43 +62,37 @@ public class ReloadingVFSContextClassLoaderFactoryTest {
       this.dir = dir;
     }
 
+    @SuppressFBWarnings(value = "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED",
+        justification = "Security Manager is deprecated for removal as of JDK 17")
     @Override
     protected AccumuloVFSClassLoader create(Context c) {
-      AccumuloVFSClassLoader acl =
-          AccessController.doPrivileged(new PrivilegedAction<AccumuloVFSClassLoader>() {
+      final AccumuloVFSClassLoader cl =
+          new AccumuloVFSClassLoader(ReloadingVFSContextClassLoaderFactory.class.getClassLoader()) {
             @Override
-            public AccumuloVFSClassLoader run() {
-              AccumuloVFSClassLoader cl = new AccumuloVFSClassLoader(
-                  ReloadingVFSContextClassLoaderFactory.class.getClassLoader()) {
-                @Override
-                protected String getClassPath() {
-                  return dir;
-                }
-
-                @Override
-                protected boolean isPostDelegationModel() {
-                  LOG.debug("isPostDelegationModel called, returning {}",
-                      c.getConfig().getPostDelegate());
-                  return c.getConfig().getPostDelegate();
-                }
-
-                @Override
-                protected long getMonitorInterval() {
-                  return 500l;
-                }
-
-                @Override
-                protected boolean isVMInitialized() {
-                  return true;
-                }
-              };
-              cl.setVMInitializedForTests();
-              cl.setMaxRetries(2);
-              return cl;
+            protected String getClassPath() {
+              return dir;
             }
 
-          });
-      return acl;
+            @Override
+            protected boolean isPostDelegationModel() {
+              LOG.debug("isPostDelegationModel called, returning {}",
+                  c.getConfig().getPostDelegate());
+              return c.getConfig().getPostDelegate();
+            }
+
+            @Override
+            protected long getMonitorInterval() {
+              return 500l;
+            }
+
+            @Override
+            protected boolean isVMInitialized() {
+              return true;
+            }
+          };
+      cl.setVMInitializedForTests();
+      cl.setMaxRetries(2);
+      return cl;
     }
   }
 


### PR DESCRIPTION
The SecurityManager and related classes, including AccessController, have been deprecated as of JDK 17 and are planned for removal. This commit removes the usage of the APIs.

References:
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/SecurityManager.html
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/AccessController.html