### PR TITLE
Add more information to exceptions from UniqueFileReplicator

### DIFF
--- a/modules/vfs-class-loader/src/main/java/org/apache/accumulo/classloader/vfs/UniqueFileReplicator.java
+++ b/modules/vfs-class-loader/src/main/java/org/apache/accumulo/classloader/vfs/UniqueFileReplicator.java
@@ -57,8 +57,16 @@ public class UniqueFileReplicator implements VfsComponent, FileReplicator {
     String baseName = srcFile.getName().getBaseName();
 
     try {
+      if (!tempDir.exists()) {
+        throw new IOException("Directory no longer exists: " + tempDir.getAbsolutePath());
+      }
       String safeBasename = UriParser.encode(baseName, TMP_RESERVED_CHARS).replace('%', '_');
-      File file = File.createTempFile("vfsr_", "_" + safeBasename, tempDir);
+      File file = null;
+      try {
+        file = File.createTempFile("vfsr_", "_" + safeBasename, tempDir);
+      } catch (IOException ioe) {
+        throw new IOException("Error creating temp file in directory: " + tempDir, ioe);
+      }
       file.deleteOnExit();
 
       final FileObject destFile = context.toFileObject(file);


### PR DESCRIPTION
These changes were made in Accumulo version 2.1.4. Porting them to this repo for use in future versions of Accumulo where the VFSClassLoader has been removed.