### PR TITLE
Simplify file names for downloaded definitions

### DIFF
--- a/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/LocalCachingContextClassLoaderFactory.java
+++ b/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/LocalCachingContextClassLoaderFactory.java
@@ -111,10 +111,10 @@ public class LocalCachingContextClassLoaderFactory implements ContextClassLoader
    * (if it changed).
    */
   private void monitorContext(final String contextLocation, long interval) {
-    EXECUTOR.schedule(() -> checkMonitoredLocation(contextLocation, interval), interval,
-        TimeUnit.SECONDS);
     LOG.trace("Monitoring context definition file {} for changes at {} second intervals",
         contextLocation, interval);
+    EXECUTOR.schedule(() -> checkMonitoredLocation(contextLocation, interval), interval,
+        TimeUnit.SECONDS);
   }
 
   // for tests only

--- a/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/definition/ContextDefinition.java
+++ b/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/definition/ContextDefinition.java
@@ -48,11 +48,6 @@ public class ContextDefinition {
 
   public static ContextDefinition create(int monitorIntervalSecs, URL... sources)
       throws IOException {
-    return create("unknown", monitorIntervalSecs, sources);
-  }
-
-  public static ContextDefinition create(String sourceFileName, int monitorIntervalSecs,
-      URL... sources) throws IOException {
     LinkedHashSet<Resource> resources = new LinkedHashSet<>();
     for (URL u : sources) {
       FileResolver resolver = FileResolver.resolve(u);
@@ -61,7 +56,7 @@ public class ContextDefinition {
         resources.add(new Resource(u, checksum));
       }
     }
-    return new ContextDefinition(sourceFileName, monitorIntervalSecs, resources);
+    return new ContextDefinition(monitorIntervalSecs, resources);
   }
 
   public static ContextDefinition fromRemoteURL(final URL url) throws IOException {
@@ -71,13 +66,11 @@ public class ContextDefinition {
       if (def == null) {
         throw new EOFException("InputStream does not contain a valid ContextDefinition at " + url);
       }
-      def.sourceFileName = resolver.getFileName();
       return def;
     }
   }
 
   // transient fields that don't go in the json
-  private transient String sourceFileName;
   private final transient Supplier<String> checksum =
       Suppliers.memoize(() -> DIGESTER.digestAsHex(toJson()));
 
@@ -88,18 +81,11 @@ public class ContextDefinition {
 
   public ContextDefinition() {}
 
-  public ContextDefinition(String sourceFileName, int monitorIntervalSeconds,
-      LinkedHashSet<Resource> resources) {
-    this.sourceFileName = requireNonNull(sourceFileName, "source file name must be supplied");
-
+  public ContextDefinition(int monitorIntervalSeconds, LinkedHashSet<Resource> resources) {
     Preconditions.checkArgument(monitorIntervalSeconds > 0,
         "monitor interval must be greater than zero");
     this.monitorIntervalSeconds = monitorIntervalSeconds;
     this.resources = requireNonNull(resources, "resources must be supplied");
-  }
-
-  public String getSourceFileName() {
-    return sourceFileName;
   }
 
   public int getMonitorIntervalSeconds() {
@@ -112,7 +98,7 @@ public class ContextDefinition {
 
   @Override
   public int hashCode() {
-    return hash(sourceFileName, monitorIntervalSeconds, resources);
+    return hash(monitorIntervalSeconds, resources);
   }
 
   @Override
@@ -127,8 +113,7 @@ public class ContextDefinition {
       return false;
     }
     ContextDefinition other = (ContextDefinition) obj;
-    return Objects.equals(sourceFileName, other.sourceFileName)
-        && monitorIntervalSeconds == other.monitorIntervalSeconds
+    return monitorIntervalSeconds == other.monitorIntervalSeconds
         && Objects.equals(resources, other.resources);
   }
 

--- a/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/util/LocalStore.java
+++ b/modules/local-caching-classloader/src/main/java/org/apache/accumulo/classloader/lcc/util/LocalStore.java
@@ -112,7 +112,7 @@ public final class LocalStore {
   // extension, and will instead just append the checksum to the original file name
   private static Pattern fileNamesWithExtensionPattern = Pattern.compile("^(.*[^.].*)[.]([^.]+)$");
 
-  static String localName(String remoteFileName, String checksum) {
+  static String localResourceName(String remoteFileName, String checksum) {
     requireNonNull(remoteFileName);
     requireNonNull(checksum);
     var matcher = fileNamesWithExtensionPattern.matcher(remoteFileName);
@@ -134,11 +134,7 @@ public final class LocalStore {
     requireNonNull(contextDefinition, "definition must be supplied");
     // use a LinkedHashSet to preserve the order of the context resources
     final Set<Path> localFiles = new LinkedHashSet<>();
-    // store it with a .json suffix, if the original file didn't have one
-    final String origSourceName = contextDefinition.getSourceFileName();
-    final String sourceNameWithSuffix =
-        origSourceName.toLowerCase().endsWith(".json") ? origSourceName : origSourceName + ".json";
-    final String destinationName = localName(sourceNameWithSuffix, contextDefinition.getChecksum());
+    final String destinationName = contextDefinition.getChecksum() + ".json";
     try {
       storeContextDefinition(contextDefinition, destinationName);
       boolean successful = false;
@@ -200,7 +196,7 @@ public final class LocalStore {
   private Path storeResource(final Resource resource) throws IOException {
     final URL url = resource.getLocation();
     final FileResolver source = FileResolver.resolve(url);
-    final String baseName = localName(source.getFileName(), resource.getChecksum());
+    final String baseName = localResourceName(source.getFileName(), resource.getChecksum());
     final Path destinationPath = resourcesDir.resolve(baseName);
     final Path tempPath = resourcesDir.resolve(tempName(baseName));
     final Path downloadingProgressPath = resourcesDir.resolve("." + baseName + ".downloading");
@@ -250,7 +246,7 @@ public final class LocalStore {
           Files.write(downloadingProgressPath, PID.getBytes(UTF_8), TRUNCATE_EXISTING);
         } catch (IOException e) {
           LOG.warn(
-              "Error writing progress file {}. Other processes may attempt downloading the same file.",
+              "Error writing progress file {}. Other processes may attempt to download the same file concurrently.",
               downloadingProgressPath, e);
         }
         try {

--- a/modules/local-caching-classloader/src/test/java/org/apache/accumulo/classloader/lcc/LocalCachingContextClassLoaderFactoryTest.java
+++ b/modules/local-caching-classloader/src/test/java/org/apache/accumulo/classloader/lcc/LocalCachingContextClassLoaderFactoryTest.java
@@ -133,7 +133,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     final URL jarCJettyLocation = jetty.getURI().resolve("TestC.jar").toURL();
 
     // ContextDefinition with all jars
-    var allJarsDef = ContextDefinition.create("all", MONITOR_INTERVAL_SECS, jarAOrigLocation,
+    var allJarsDef = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation,
         jarBHdfsLocation, jarCJettyLocation, jarDOrigLocation);
     String allJarsDefJson = allJarsDef.toJson();
 
@@ -226,7 +226,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
   @Test
   public void testInitialInvalidJson() throws Exception {
     // Create a new context definition file in HDFS, but with invalid content
-    var def = ContextDefinition.create("invalid", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     // write out invalid json
     final Path invalid = createContextDefinitionFile(fs, "InvalidContextDefinitionFile.json",
         def.toJson().substring(0, 4));
@@ -240,7 +240,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testInitial() throws Exception {
-    var def = ContextDefinition.create("initial", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path initial =
         createContextDefinitionFile(fs, "InitialContextDefinitionFile.json", def.toJson());
     final URL initialDefUrl = new URL(fs.getUri().toString() + initial.toUri().toString());
@@ -264,7 +264,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     Files.copy(jarAPath, jarACopy, StandardCopyOption.REPLACE_EXISTING);
     assertTrue(Files.exists(jarACopy));
 
-    var def = ContextDefinition.create("initial", MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
+    var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
 
     Files.delete(jarACopy);
     assertTrue(!Files.exists(jarACopy));
@@ -284,7 +284,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     resources.add(new Resource(jarAOrigLocation, "1234"));
 
     // remove the file:// prefix from the URL
-    String goodJson = new ContextDefinition("initial", MONITOR_INTERVAL_SECS, resources).toJson();
+    String goodJson = new ContextDefinition(MONITOR_INTERVAL_SECS, resources).toJson();
     String badJson =
         goodJson.replace(jarAOrigLocation.toString(), jarAOrigLocation.toString().substring(6));
     assertNotEquals(goodJson, badJson);
@@ -309,7 +309,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     LinkedHashSet<Resource> resources = new LinkedHashSet<>();
     resources.add(r);
 
-    var def = new ContextDefinition("initial", MONITOR_INTERVAL_SECS, resources);
+    var def = new ContextDefinition(MONITOR_INTERVAL_SECS, resources);
 
     final Path initial = createContextDefinitionFile(fs,
         "InitialContextDefinitionBadResourceChecksum.json", def.toJson());
@@ -332,7 +332,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdate() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateContextDefinitionFile.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -345,7 +345,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     testClassFailsToLoad(cl, classD);
 
     // Update the contents of the context definition json file
-    var updateDef = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarDOrigLocation);
+    var updateDef = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarDOrigLocation);
     updateContextDefinitionFile(fs, defFilePath, updateDef.toJson());
 
     // wait 2x the monitor interval
@@ -363,7 +363,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateSameClassNameDifferentContent() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateContextDefinitionFile.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -376,7 +376,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     testClassFailsToLoad(cl, classD);
 
     // Update the contents of the context definition json file
-    var updateDef = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarEOrigLocation);
+    var updateDef = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarEOrigLocation);
     updateContextDefinitionFile(fs, defFilePath, updateDef.toJson());
 
     // wait 2x the monitor interval
@@ -396,7 +396,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateContextDefinitionEmpty() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateEmptyContextDefinitionFile.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -427,7 +427,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateNonExistentResource() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateNonExistentResource.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -449,7 +449,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     assertTrue(!Files.exists(jarACopy));
     Files.copy(jarAPath, jarACopy, StandardCopyOption.REPLACE_EXISTING);
     assertTrue(Files.exists(jarACopy));
-    var def2 = ContextDefinition.create("initial", MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
+    var def2 = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
     Files.delete(jarACopy);
     assertTrue(!Files.exists(jarACopy));
 
@@ -470,7 +470,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateBadResourceChecksum() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateBadResourceChecksum.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -486,7 +486,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     LinkedHashSet<Resource> resources = new LinkedHashSet<>();
     resources.add(r);
 
-    var def2 = new ContextDefinition("update", MONITOR_INTERVAL_SECS, resources);
+    var def2 = new ContextDefinition(MONITOR_INTERVAL_SECS, resources);
 
     updateContextDefinitionFile(fs, defFilePath, def2.toJson());
 
@@ -505,7 +505,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateBadResourceURL() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateBadResourceChecksum.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -520,7 +520,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     // remove the file:// prefix from the URL
     LinkedHashSet<Resource> resources = new LinkedHashSet<>();
     resources.add(new Resource(jarAOrigLocation, "1234"));
-    String goodJson = new ContextDefinition("initial", MONITOR_INTERVAL_SECS, resources).toJson();
+    String goodJson = new ContextDefinition(MONITOR_INTERVAL_SECS, resources).toJson();
     String badJson =
         goodJson.replace(jarAOrigLocation.toString(), jarAOrigLocation.toString().substring(6));
     assertNotEquals(goodJson, badJson);
@@ -542,7 +542,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testUpdateInvalidJson() throws Exception {
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateInvalidContextDefinitionFile.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -554,7 +554,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     testClassFailsToLoad(cl, classC);
     testClassFailsToLoad(cl, classD);
 
-    var updateDef = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarDOrigLocation);
+    var updateDef = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarDOrigLocation);
     updateContextDefinitionFile(fs, defFilePath, updateDef.toJson().substring(0, 4));
 
     // wait 2x the monitor interval
@@ -587,8 +587,8 @@ public class LocalCachingContextClassLoaderFactoryTest {
 
   @Test
   public void testChangingContext() throws Exception {
-    var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation,
-        jarBOrigLocation, jarCOrigLocation, jarDOrigLocation);
+    var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation, jarBOrigLocation,
+        jarCOrigLocation, jarDOrigLocation);
     final Path update =
         createContextDefinitionFile(fs, "UpdateChangingContextDefinition.json", def.toJson());
     final URL updatedDefUrl = new URL(fs.getUri().toString() + update.toUri().toString());
@@ -614,8 +614,8 @@ public class LocalCachingContextClassLoaderFactoryTest {
       final URL removed = updatedList.remove(0);
 
       // Update the contents of the context definition json file
-      var updateDef = ContextDefinition.create("update", MONITOR_INTERVAL_SECS,
-          updatedList.toArray(new URL[] {}));
+      var updateDef =
+          ContextDefinition.create(MONITOR_INTERVAL_SECS, updatedList.toArray(new URL[0]));
       updateContextDefinitionFile(fs, update, updateDef.toJson());
 
       // wait 2x the monitor interval
@@ -667,7 +667,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
         Map.of(CACHE_DIR_PROPERTY, baseCacheDir, UPDATE_FAILURE_GRACE_PERIOD_MINS, "1"));
     localFactory.init(() -> new ConfigurationImpl(acuConf));
 
-    final var def = ContextDefinition.create("update", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+    final var def = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final Path defFilePath =
         createContextDefinitionFile(fs, "UpdateNonExistentResource.json", def.toJson());
     final URL updateDefUrl = new URL(fs.getUri().toString() + defFilePath.toUri().toString());
@@ -689,7 +689,7 @@ public class LocalCachingContextClassLoaderFactoryTest {
     assertTrue(!Files.exists(jarACopy));
     Files.copy(jarAPath, jarACopy, StandardCopyOption.REPLACE_EXISTING);
     assertTrue(Files.exists(jarACopy));
-    var def2 = ContextDefinition.create("initial", MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
+    var def2 = ContextDefinition.create(MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
     Files.delete(jarACopy);
     assertTrue(!Files.exists(jarACopy));
 

--- a/modules/local-caching-classloader/src/test/java/org/apache/accumulo/classloader/lcc/MiniAccumuloClusterClassLoaderFactoryTest.java
+++ b/modules/local-caching-classloader/src/test/java/org/apache/accumulo/classloader/lcc/MiniAccumuloClusterClassLoaderFactoryTest.java
@@ -137,7 +137,7 @@ public class MiniAccumuloClusterClassLoaderFactoryTest extends SharedMiniCluster
 
     // Create a context definition that only references jar A
     final ContextDefinition testContextDef =
-        ContextDefinition.create("test", MONITOR_INTERVAL_SECS, jarAOrigLocation);
+        ContextDefinition.create(MONITOR_INTERVAL_SECS, jarAOrigLocation);
     final String testContextDefJson = testContextDef.toJson();
     final File testContextDefFile = jsonDirPath.resolve("testContextDefinition.json").toFile();
     Files.writeString(testContextDefFile.toPath(), testContextDefJson, StandardOpenOption.CREATE);
@@ -212,7 +212,7 @@ public class MiniAccumuloClusterClassLoaderFactoryTest extends SharedMiniCluster
 
       // Update the context definition to point to jar B
       final ContextDefinition testContextDefUpdate =
-          ContextDefinition.create("test", MONITOR_INTERVAL_SECS, jarBOrigLocation);
+          ContextDefinition.create(MONITOR_INTERVAL_SECS, jarBOrigLocation);
       final String testContextDefUpdateJson = testContextDefUpdate.toJson();
       Files.writeString(testContextDefFile.toPath(), testContextDefUpdateJson,
           StandardOpenOption.TRUNCATE_EXISTING);
@@ -239,7 +239,7 @@ public class MiniAccumuloClusterClassLoaderFactoryTest extends SharedMiniCluster
       assertTrue(Files.exists(jarACopy));
 
       final ContextDefinition testContextDefUpdate2 =
-          ContextDefinition.create("test", MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
+          ContextDefinition.create(MONITOR_INTERVAL_SECS, jarACopy.toUri().toURL());
       Files.delete(jarACopy);
       assertTrue(!Files.exists(jarACopy));
 


### PR DESCRIPTION
* Use checksum.json instead of attempting to track the original file name in the remote URL for the context definition
* This avoids weird edge cases, like when an HTTP url for a context definition ends with /, which is a valid HTTP url, but has no associated file name to parse out
* This also prevents duplicate local copies of the same context definition downloaded from different source URLs