### PR TITLE
Apply updates for building with Java 21 and more

### DIFF
--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -39,12 +39,12 @@ jobs:
     name: mvn (triggered by ${{ github.event.sender.login }})
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Build with Maven
       timeout-minutes: 345
@@ -53,14 +53,14 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -35,12 +35,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Build with Maven (verify javadoc:jar)
       run: mvn -B -V -e -ntp "-Dstyle.color=always" verify javadoc:jar -DskipFormat -DverifyFormat
@@ -48,14 +48,14 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/

--- a/modules/caching-class-loader/src/main/java/org/apache/accumulo/classloader/ccl/LocalStore.java
+++ b/modules/caching-class-loader/src/main/java/org/apache/accumulo/classloader/ccl/LocalStore.java
@@ -423,8 +423,9 @@ public final class LocalStore {
   static class HardLinkFailedException extends Exception {
 
     private static final long serialVersionUID = 1L;
-    private final Path destDir;
-    private Path missingResource;
+    // Path isn't serializable; that's okay, since we don't need this exception serialized
+    private final transient Path destDir;
+    private final transient Path missingResource;
 
     HardLinkFailedException(Path destDir, Path missingResource, NoSuchFileException cause) {
       super("Creating hard link in directory " + destDir + " failed", cause);

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>35</version>
+    <version>37</version>
     <relativePath />
   </parent>
   <groupId>org.apache.accumulo</groupId>
@@ -112,17 +112,19 @@ specific language governing permissions and limitations
 under the License.
 ]]></accumulo.build.license.header>
     <failsafe.failIfNoSpecifiedTests>false</failsafe.failIfNoSpecifiedTests>
-    <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <javaVersion>11</javaVersion>
+    <!-- prevent introduction of new compiler warnings -->
+    <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
+    <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
     <maven.site.skip>true</maven.site.skip>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
-    <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
     <minimalMavenBuildVersion>3.9</minimalMavenBuildVersion>
+    <modernizer.javaVersion>${javaVersion}</modernizer.javaVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-08-27T15:56:15Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
@@ -155,7 +157,7 @@ under the License.
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.4.3</version>
+        <version>5.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -173,7 +175,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.19.0</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
@@ -211,9 +213,6 @@ under the License.
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
           <version>3.2.0</version>
-          <configuration>
-            <javaVersion>${maven.compiler.target}</javaVersion>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>
@@ -259,7 +258,7 @@ under the License.
         <plugin>
           <groupId>com.github.koraktor</groupId>
           <artifactId>mavanagaiata</artifactId>
-          <version>1.1.1</version>
+          <version>1.1.2</version>
           <configuration>
             <skipNoGit>true</skipNoGit>
           </configuration>
@@ -276,6 +275,13 @@ under the License.
               <arg>-Xmaxwarns</arg>
               <arg>5</arg>
             </compilerArgs>
+            <annotationProcessorPaths combine.children="append">
+              <path>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${version.auto-service}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>
@@ -305,11 +311,10 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <arguments>-P !autoformat,verifyformat</arguments>
             <goals>clean deploy</goals>
             <preparationGoals>clean verify</preparationGoals>
             <tagNameFormat>rel/@{project.artifactId}-@{project.version}</tagNameFormat>
-            <releaseProfiles>apache-release</releaseProfiles>
+            <releaseProfiles>apache-release,accumulo-release,!autoformat,verifyformat</releaseProfiles>
             <useReleaseProfile>false</useReleaseProfile>
             <pushChanges>false</pushChanges>
             <localCheckout>true</localCheckout>
@@ -323,13 +328,16 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
           <version>2.29.0</version>
           <configuration>
+            <compilerCompliance>${javaVersion}</compilerCompliance>
+            <compilerSource>${javaVersion}</compilerSource>
+            <compilerTargetPlatform>${javaVersion}</compilerTargetPlatform>
             <configFile>${rootlocation}/src/build/eclipse-codestyle.xml</configFile>
             <lineEnding>LF</lineEnding>
             <skipCssFormatting>true</skipCssFormatting>
@@ -352,7 +360,7 @@ under the License.
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.12.0</version>
+          <version>1.13.0</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -384,6 +392,15 @@ under the License.
                 <!-- spotbugs annotations may or may not be used in each module -->
                 <unused>com.github.spotbugs:spotbugs-annotations:jar:*</unused>
               </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+          <execution>
+            <id>analyze-exclusions</id>
+            <goals>
+              <goal>analyze-exclusions</goal>
+            </goals>
+            <configuration>
+              <exclusionFail>true</exclusionFail>
             </configuration>
           </execution>
         </executions>
@@ -475,7 +492,7 @@ under the License.
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>11.0.1</version>
+            <version>13.2.0</version>
           </dependency>
         </dependencies>
         <executions>
@@ -650,6 +667,12 @@ under the License.
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>accumulo-release</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
     <profile>
       <!-- off by default, but enable with '-P verifyformat' or '-DverifyFormat' -->
       <id>verifyformat</id>


### PR DESCRIPTION
* Update GitHub Actions
* Fix serialization problem with HardLinkFailedException by making fields transient
* Avoid memoizing Supplier for lazy initialization of manifest checksum
* Update parent POM and plugins, and test dependencies
* Add analysis for unused exclusions from dependencies